### PR TITLE
Fix a bug that breaks release builds

### DIFF
--- a/src/arcs.rs
+++ b/src/arcs.rs
@@ -97,6 +97,8 @@ impl<T: Clone> Arcs<T> {
             ThinArc::from_header_and_iter((), Initializer(slice.iter(), new_len - old_len, f));
 
         let _old = self.array.swap(Some(arc));
+
+        #[cfg(debug_assertions)]
         debug_assert!(slice.is_same_arc(_old.as_ref()));
     }
 }


### PR DESCRIPTION
Release build failed with 

```console
❯ cargo build --release
   Compiling concurrent_arena v0.1.5 (/Users/bax/projects/concurrent_arena)
error[E0599]: no method named `is_same_arc` found for struct `Slice<'_, T>` in the current scope
   --> src/arcs.rs:100:29
    |
100 |         debug_assert!(slice.is_same_arc(_old.as_ref()));
    |                             ^^^^^^^^^^^ method not found in `Slice<'_, T>`
...
105 | pub(crate) struct Slice<'a, T>(Guard<Option<ThinArc<(), T>>>, PhantomData<&'a Arcs<T>>);
    | ---------------------------------------------------------------------------------------- method `is_same_arc` not found for this

For more information about this error, try `rustc --explain E0599`.
error: could not compile `concurrent_arena` due to previous error
```

To fix this, I flag code that **only** works in debug mode

There a `slice.is_same_arc` call in a debug assert. The `is_same_arc` method is behind the `debug_assertions` flag, which compiles in debug mode, but not in release mode. The `debug_assert!` in `Arcs::do_grow` contained a `is_same_arc` call, but `debug_assert` was still being compiled in release, so it failed.

Note: I didn't bump the version number or anything like that.