### PR TITLE
Refactor: improve a lot in `arcs`, `arena`, `bitmap`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,7 @@ thread-sanitizer = []
 
 [dependencies]
 array-init = "2.0.0"
-
 parking_lot = "0.12.0"
-
 triomphe = { version = "0.1.5", features = ["arc-swap"] }
 arc-swap = "1.5.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "concurrent_arena"
 version = "0.1.7"
 edition = "2018"
+rust-version = "1.58"
 
 license = "MIT"
 description = "u32 concurrent insertion/removal arena that returns ArenaArc"
@@ -14,7 +15,6 @@ categories = ["concurrency"]
 thread-sanitizer = []
 
 [dependencies]
-const_fn_assert = "0.1.2"
 array-init = "2.0.0"
 
 parking_lot = "0.12.0"

--- a/src/arcs.rs
+++ b/src/arcs.rs
@@ -59,9 +59,8 @@ impl<T: Clone> Arcs<T> {
 
     fn do_grow(&self, new_len: usize, f: impl FnMut() -> T) {
         let slice = self.as_slice();
-        let slice_ref = &*slice;
 
-        let old_len = slice_ref.len();
+        let old_len = slice.len();
         if old_len >= new_len {
             return;
         }
@@ -92,7 +91,7 @@ impl<T: Clone> Arcs<T> {
         impl<T: Clone, F: FnMut() -> T> ExactSizeIterator for Initializer<'_, T, F> {}
 
         let arc =
-            ThinArc::from_header_and_iter((), Initializer(slice_ref.iter(), new_len - old_len, f));
+            ThinArc::from_header_and_iter((), Initializer(slice.iter(), new_len - old_len, f));
 
         let _old = self.array.swap(Some(arc));
 

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -5,7 +5,7 @@ use core::cmp::min;
 /// * `LEN` - Number of elements stored per bucket.
 ///    Must be less than or equal to `u32::MAX`, divisible by
 ///   `usize::BITS` and it must not be `0`.
-/// * `BITARRAY_LEN` - Number of usize in the bitmap per bucket.
+/// * `BITARRAY_LEN` - Number of [`usize`] in the bitmap per bucket.
 ///   Must be equal to `LEN / usize::BITS`.
 ///
 ///   For best performance, try to set this to number of CPUs that are going
@@ -102,7 +102,7 @@ impl<T: Send + Sync, const BITARRAY_LEN: usize, const LEN: usize> Arena<T, BITAR
     ///
     /// This function is lock-free.
     pub fn try_insert(&self, mut value: T) -> Result<ArenaArc<T, BITARRAY_LEN, LEN>, (T, u32)> {
-        let slice = &*self.buckets.as_slice();
+        let slice = self.buckets.as_slice();
         let len = slice.len();
 
         debug_assert!(len <= Self::max_buckets() as usize);

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -2,12 +2,10 @@ use super::{arcs::Arcs, bucket::Bucket, thread_id::get_thread_id, Arc, ArenaArc}
 
 use core::cmp::min;
 
-use const_fn_assert::{cfn_assert, cfn_assert_eq, cfn_assert_ne};
-
 /// * `LEN` - Number of elements stored per bucket.
 ///    Must be less than or equal to `u32::MAX`, divisible by
 ///   `usize::BITS` and it must not be `0`.
-/// * `BITARRAY_LEN` - Number bits in the bitmap per bucket.
+/// * `BITARRAY_LEN` - Number of usize in the bitmap per bucket.
 ///   Must be equal to `LEN / usize::BITS`.
 ///
 ///   For best performance, try to set this to number of CPUs that are going
@@ -60,11 +58,16 @@ impl<T: Sync + Send, const BITARRAY_LEN: usize, const LEN: usize> Default
 const fn check_const_generics<const BITARRAY_LEN: usize, const LEN: usize>() {
     let bits = usize::BITS as usize;
 
-    cfn_assert!(LEN <= (u32::MAX as usize));
-    cfn_assert_eq!(LEN % bits, 0);
-    cfn_assert_ne!(LEN, 0);
-
-    cfn_assert_eq!(LEN / bits, BITARRAY_LEN);
+    assert!(
+        LEN <= (u32::MAX as usize),
+        "LEN must be less than or equal to u32::MAX"
+    );
+    assert!(LEN % bits == 0, "LEN must be divisible by usize::BITS");
+    assert!(LEN != 0, "LEN must not be 0");
+    assert!(
+        LEN / bits == BITARRAY_LEN,
+        "BITARRAY_LEN must be equal to LEN / usize::BITS"
+    );
 }
 
 impl<T, const BITARRAY_LEN: usize, const LEN: usize> Arena<T, BITARRAY_LEN, LEN> {
@@ -99,7 +102,7 @@ impl<T: Send + Sync, const BITARRAY_LEN: usize, const LEN: usize> Arena<T, BITAR
     ///
     /// This function is lock-free.
     pub fn try_insert(&self, mut value: T) -> Result<ArenaArc<T, BITARRAY_LEN, LEN>, (T, u32)> {
-        let slice = self.buckets.as_slice();
+        let slice = &*self.buckets.as_slice();
         let len = slice.len();
 
         debug_assert!(len <= Self::max_buckets() as usize);


### PR DESCRIPTION
Update:
- Add `msrv` in `Cargo.toml`
- Remove unnecessary `new_len != 0` in `arcs.rs`
- Refactor `slice` to dereference first to avoid unnecessary multiple dereferences
- Using `assert` in const context
- Simplify atomic operations in `bitmap.rs`