### PR TITLE
Improve CI

### DIFF
--- a/.github/workflows/minimal.yml
+++ b/.github/workflows/minimal.yml
@@ -1,0 +1,37 @@
+name: Minimal
+
+env:
+  RUSTFLAGS: -Dwarnings
+  RUST_BACKTRACE: 1
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+  CARGO_UNSTABLE_SPARSE_REGISTRY: true
+
+on:
+  push:
+    paths-ignore:
+      - 'README.md'
+      - 'LICENSE'
+      - '.gitignore'
+  pull_request:
+    paths-ignore:
+      - 'README.md'
+      - 'LICENSE'
+      - '.gitignore'
+
+jobs:
+  minimal:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install nightly rust
+      run: rustup toolchain install nightly --no-self-update --profile minimal
+
+    - name: Create Cargo.lock containing the minimal versions
+      run: cargo +nightly update -Zminimal-versions
+
+    - uses: Swatinem/rust-cache@v2
+    - name: Check with minimal version of deps
+      run: cargo check --lib --locked

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -1,7 +1,12 @@
 name: Miri
 
 env:
+  RUSTFLAGS: -Dwarnings
+  RUST_BACKTRACE: 1
   CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+  CARGO_UNSTABLE_SPARSE_REGISTRY: true
 
 on:
   push:
@@ -10,6 +15,11 @@ on:
       - 'README.md'
       - 'LICENSE'
       - '.gitignore'
+  #pull_request:
+  #  paths-ignore:
+  #    - 'README.md'
+  #    - 'LICENSE'
+  #    - '.gitignore'
 
 jobs:
   miri:
@@ -17,21 +27,21 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ github.event.repository.name }}-${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.toml') }}-v2
     - name: Install latest nightly
-      uses: actions-rs/toolchain@v1
+      run: |
+        rustup toolchain install nightly --component miri --no-self-update --profile minimal
+        rustup default nightly
+    - uses: taiki-e/install-action@v2
       with:
-          toolchain: nightly
-          components: miri
+        tool: cargo-nextest
+
+    - uses: Swatinem/rust-cache@v2
     - name: Miri
-      run: cargo +nightly miri test -- --nocapture
+      run: |
+        cargo +nightly miri \
+            nextest run \
+            -Z build-std \
+            --target "$(rustc -vV | grep host | cut -d : -f 2 | tr -d '[:space:]')" \
+            --release
       env:
         MIRIFLAGS: -Zmiri-disable-isolation

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -1,0 +1,36 @@
+name: Msrv
+
+env:
+  RUSTFLAGS: -Dwarnings
+  RUST_BACKTRACE: 1
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+  CARGO_UNSTABLE_SPARSE_REGISTRY: true
+
+on:
+  push:
+    paths-ignore:
+      - 'README.md'
+      - 'LICENSE'
+      - '.gitignore'
+  pull_request:
+    paths-ignore:
+      - 'README.md'
+      - 'LICENSE'
+      - '.gitignore'
+
+jobs:
+  msrv:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install rust 1.58
+      run: |
+        rustup toolchain install 1.58 --no-self-update --profile minimal
+        rustup default 1.58
+
+    - uses: Swatinem/rust-cache@v2
+    - name: Check msrv
+      run: cargo check --lib

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,7 +1,12 @@
 name: Rust
 
 env:
+  RUSTFLAGS: -Dwarnings
+  RUST_BACKTRACE: 1
   CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+  CARGO_UNSTABLE_SPARSE_REGISTRY: true
 
 on:
   push:
@@ -28,32 +33,18 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ github.event.repository.name }}-${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}-v2
+
+    - uses: Swatinem/rust-cache@v2
     - name: Run clippy
-      run: cargo clippy --all --all-features
+      run: cargo clippy --all --all-features --no-deps
 
   test:
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ github.event.repository.name }}-${{ runner.os }}-cargo-test-v3
+
+    - uses: Swatinem/rust-cache@v2
     - name: Run tests
       run: cargo test
 
@@ -62,15 +53,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ github.event.repository.name }}-${{ runner.os }}-cargo-test-release-v3
+
+    - uses: Swatinem/rust-cache@v2
     - name: Run tests
       run: cargo test --release
 
@@ -79,50 +63,35 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ github.event.repository.name }}-${{ runner.os }}-cargo-test-sanitize-address-v3
     - name: Install latest nightly
-      uses: actions-rs/toolchain@v1
-      with:
-          toolchain: nightly
+      run: |
+        rustup toolchain install nightly --no-self-update --profile minimal
+        rustup default nightly
+
+    - uses: Swatinem/rust-cache@v2
     - name: Run tests
       run: cargo +nightly test
       env:
-        RUSTFLAGS: -Zsanitizer=address
-        RUSTDOCFLAGS: -Zsanitizer=address
+        RUSTFLAGS: -Zsanitizer=address ${{ env.RUSTFLAGS }}
+        RUSTDOCFLAGS: -Zsanitizer=address ${{ env.RUSTFLAGS }}
 
   test-sanitize-thread:
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ github.event.repository.name }}-${{ runner.os }}-cargo-test-sanitize-thread-v3
     - name: Install latest nightly
-      uses: actions-rs/toolchain@v1
-      with:
-          toolchain: nightly
-          components: rust-src
+      run: |
+        rustup toolchain install nightly --component rust-src --no-self-update --profile minimal
+        rustup default nightly
+
+    - uses: Swatinem/rust-cache@v2
     - name: Run tests
       run: |
         cargo +nightly test \
                 -Z build-std \
-                --target $(rustc -vV | grep host | cut -d : -f 2) \
+                --target "$(rustc -vV | grep host | cut -d : -f 2 | tr -d '[:space:]')" \
                 --features thread-sanitizer
       env:
-        RUSTFLAGS: -Zsanitizer=thread
-        RUSTDOCFLAGS: -Zsanitizer=thread
+        RUSTFLAGS: -Zsanitizer=thread ${{ env.RUSTFLAGS }}
+        RUSTDOCFLAGS: -Zsanitizer=thread ${{ env.RUSTFLAGS }}

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -9,26 +9,33 @@ export RUST_TEST_THREADS=1
 rep=$(seq 1 10)
 
 for _ in $rep; do
+    # shellcheck disable=SC2068
     cargo test $@ -- --nocapture
 done
 
 export RUSTFLAGS='-Zsanitizer=address'
 export RUSTDOCFLAGS="$RUSTFLAGS"
 for _ in $rep; do
+    # shellcheck disable=SC2068
     cargo +nightly test $@ -- --nocapture
 done
 
 export RUSTFLAGS='-Zsanitizer=thread' 
 export RUSTDOCFLAGS="$RUSTFLAGS"
 
-target=$(rustc -vV | grep host | cut -d : -f 2)
+target="$(rustc -vV | grep host | cut -d : -f 2 | tr -d '[:space:]')"
 for _ in $rep; do
+    # shellcheck disable=SC2068
     cargo +nightly test $@ \
         -Z build-std \
-        --target $target \
+        --target "$target" \
         --features thread-sanitizer \
         -- --nocapture
 done
 
 #export MIRIFLAGS="-Zmiri-disable-isolation"
-#exec cargo +nightly miri test -- --nocapture
+#exec cargo +nightly miri \
+#    nextest run \
+#    -Z build-std \
+#    --target "$target" \
+#    --release


### PR DESCRIPTION
 - Enable rust backtrace for better err debugging experience
 - Turn warnings into errors
 - Disable incremental build since CI always builds from scratch
 - Use sparse crates.io registries
 - Rm use of unmaintained `actions-rs/toolchain`
 - Speedup `cargo-clippy` with `--no-deps`
 - Use `Swatinem/rust-cache@v2` for caching
 - Add workflow `msrv.yml` for checking msrv
 - Add workflow `minimal.yml` for checking with minimal version of deps
 - Fix shellcheck errors in `run_tests.sh`

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>