### PR TITLE
Fix tests on 32 bit

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -26,10 +26,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Install rust 1.58
+    - name: Install rust 1.63
       run: |
-        rustup toolchain install 1.58 --no-self-update --profile minimal
-        rustup default 1.58
+        rustup toolchain install 1.63 nightly --no-self-update --profile minimal
+        rustup default 1.63
+
+    - name: Use minimal versions
+      run: cargo +nightly update -Zminimal-versions
 
     - uses: Swatinem/rust-cache@v2
     - name: Check msrv

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Check format
       run: cargo fmt --all -- --check
       
-  Run_clippy:
+  run_clippy:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,7 +51,9 @@ jobs:
     - run: rustup target add i686-unknown-linux-musl
     
     - uses: Swatinem/rust-cache@v2
-    - run: cargo nextest run --target i686-unknown-linux-musl
+    - run: |
+        cargo nextest run --target i686-unknown-linux-musl
+        cargo test --doc --target i686-unknown-linux-musl
       
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,13 +47,11 @@ jobs:
 
     - uses: taiki-e/install-action@v2
       with:
-        tool: nextest,cross
+        tool: nextest
     - run: rustup target add i686-unknown-linux-musl
     
     - uses: Swatinem/rust-cache@v2
     - run: cargo nextest run --target i686-unknown-linux-musl
-      env:
-        CARGO_TARGET_I686_UNKNOWN_LINUX_MUSL_RUNNER: cross
       
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,6 +48,8 @@ jobs:
     - uses: taiki-e/install-action@v2
       with:
         tool: nextest,cross
+    - run: rustup target add i686-unknown-linux-musl
+    
     - uses: Swatinem/rust-cache@v2
     - run: cargo nextest run --target i686-unknown-linux-musl
       env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,6 +28,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Check format
       run: cargo fmt --all -- --check
+      
   Run_clippy:
     runs-on: ubuntu-latest
 
@@ -38,6 +39,16 @@ jobs:
     - name: Run clippy
       run: cargo clippy --all --all-features --no-deps
 
+  test-32bit:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: taiki-e/install-action@cross
+    - uses: Swatinem/rust-cache@v2
+    - run: cross test --target i686-unknown-linux-musl
+      
   test:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,9 +45,13 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: taiki-e/install-action@cross
+    - uses: taiki-e/install-action@v2
+      with:
+        tool: nextest,cross
     - uses: Swatinem/rust-cache@v2
-    - run: cross test --target i686-unknown-linux-musl
+    - run: cargo nextest run --target i686-unknown-linux-musl
+      env:
+        CARGO_TARGET_I686_UNKNOWN_LINUX_MUSL_RUNNER: cross
       
   test:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "concurrent_arena"
 version = "0.1.8"
 edition = "2018"
-rust-version = "1.58"
+rust-version = "1.63"
 
 license = "MIT"
 description = "u32 concurrent insertion/removal arena that returns ArenaArc"

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -252,14 +252,14 @@ mod tests {
 
     #[test]
     fn test_new() {
-        let arena: Arena<_, 1, 64> = Arena::new();
+        let arena: Arena<_, 1, usize::BITS> = Arena::new();
         let slot = ArenaArc::slot(&arena.insert(()));
         assert_eq!(ArenaArc::slot(&arena.remove(slot).unwrap()), slot);
     }
 
     #[test]
     fn test_with_capacity() {
-        let arena: Arena<_, 1, 64> = Arena::with_capacity(0);
+        let arena: Arena<_, 1, usize::BITS> = Arena::with_capacity(0);
         let slot = ArenaArc::slot(&arena.insert(()));
         assert_eq!(ArenaArc::slot(&arena.remove(slot).unwrap()), slot);
     }
@@ -285,7 +285,7 @@ mod tests {
         use rayon::spawn;
         use std::sync::Arc;
 
-        let arena: Arc<Arena<Mutex<u32>, 1, 64>> = Arc::new(Arena::with_capacity(0));
+        let arena: Arc<Arena<Mutex<u32>, 1, usize::BITS>> = Arc::new(Arena::with_capacity(0));
 
         (0..u16::MAX).into_par_iter().for_each(|i| {
             let i = i as u32;

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -249,17 +249,18 @@ impl<T: Send + Sync, const BITARRAY_LEN: usize, const LEN: usize> Arena<T, BITAR
 #[cfg(test)]
 mod tests {
     use crate::*;
+    const LEN: usize = usize::BITS as usize;
 
     #[test]
     fn test_new() {
-        let arena: Arena<_, 1, { usize::BITS }> = Arena::new();
+        let arena: Arena<_, 1, { LEN }> = Arena::new();
         let slot = ArenaArc::slot(&arena.insert(()));
         assert_eq!(ArenaArc::slot(&arena.remove(slot).unwrap()), slot);
     }
 
     #[test]
     fn test_with_capacity() {
-        let arena: Arena<_, 1, { usize::BITS }> = Arena::with_capacity(0);
+        let arena: Arena<_, 1, { LEN }> = Arena::with_capacity(0);
         let slot = ArenaArc::slot(&arena.insert(()));
         assert_eq!(ArenaArc::slot(&arena.remove(slot).unwrap()), slot);
     }
@@ -285,7 +286,7 @@ mod tests {
         use rayon::spawn;
         use std::sync::Arc;
 
-        let arena: Arc<Arena<Mutex<u32>, 1, { usize::BITS }>> = Arc::new(Arena::with_capacity(0));
+        let arena: Arc<Arena<Mutex<u32>, 1, { LEN }>> = Arc::new(Arena::with_capacity(0));
 
         (0..u16::MAX).into_par_iter().for_each(|i| {
             let i = i as u32;

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -252,14 +252,14 @@ mod tests {
 
     #[test]
     fn test_new() {
-        let arena: Arena<_, 1, usize::BITS> = Arena::new();
+        let arena: Arena<_, 1, { usize::BITS }> = Arena::new();
         let slot = ArenaArc::slot(&arena.insert(()));
         assert_eq!(ArenaArc::slot(&arena.remove(slot).unwrap()), slot);
     }
 
     #[test]
     fn test_with_capacity() {
-        let arena: Arena<_, 1, usize::BITS> = Arena::with_capacity(0);
+        let arena: Arena<_, 1, { usize::BITS }> = Arena::with_capacity(0);
         let slot = ArenaArc::slot(&arena.insert(()));
         assert_eq!(ArenaArc::slot(&arena.remove(slot).unwrap()), slot);
     }
@@ -285,7 +285,7 @@ mod tests {
         use rayon::spawn;
         use std::sync::Arc;
 
-        let arena: Arc<Arena<Mutex<u32>, 1, usize::BITS>> = Arc::new(Arena::with_capacity(0));
+        let arena: Arc<Arena<Mutex<u32>, 1, { usize::BITS }>> = Arc::new(Arena::with_capacity(0));
 
         (0..u16::MAX).into_par_iter().for_each(|i| {
             let i = i as u32;

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -365,7 +365,7 @@ mod tests {
 
     use rayon::prelude::*;
 
-    type Bucket<T> = super::Bucket<T, 1, { usize::BITS }>;
+    type Bucket<T> = super::Bucket<T, 1, { usize::BITS as usize }>;
 
     #[test]
     fn test_basic() {

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -365,8 +365,8 @@ mod tests {
 
     use rayon::prelude::*;
 
-    const LEN: usize = usize::BITS as usize;
-    type Bucket<T> = super::Bucket<T, 1, { LEN }>;
+    const LEN: usize = usize::BITS
+    type Bucket<T> = super::Bucket<T, 1, { LEN as usize }>;
 
     #[test]
     fn test_basic() {

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -1,6 +1,6 @@
 use super::{bitmap::BitMap, Arc, OptionExt, SliceExt};
 
-use core::{cell::UnsafeCell, hint::spin_loop, ops::Deref};
+use core::{array, cell::UnsafeCell, hint::spin_loop, ops::Deref};
 use std::sync::atomic::{fence, AtomicU8, Ordering};
 
 const REMOVED_MASK: u8 = 1 << (u8::BITS - 1);
@@ -14,8 +14,6 @@ struct Entry<T> {
 }
 
 impl<T> Entry<T> {
-    const EMPTY: Entry<T> = Entry::new();
-
     const fn new() -> Self {
         Self {
             counter: AtomicU8::new(0),
@@ -72,7 +70,7 @@ impl<T: Send + Sync, const BITARRAY_LEN: usize, const LEN: usize> Bucket<T, BITA
     pub(crate) fn new() -> Self {
         Self {
             bitset: BitMap::new(),
-            entries: [Entry::EMPTY; LEN],
+            entries: array::from_fn(|_| Entry::new()),
         }
     }
 

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -365,7 +365,7 @@ mod tests {
 
     use rayon::prelude::*;
 
-    const LEN: usize = usize::BITS
+    const LEN: usize = usize::BITS;
     type Bucket<T> = super::Bucket<T, 1, { LEN as usize }>;
 
     #[test]

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -495,7 +495,7 @@ mod tests {
                 .into_par_iter()
                 .zip(LEN..LEN + LEN / 2)
                 .for_each(|(each, i)| {
-                    assert_eq!((*each) as usize, i);
+                    assert_eq!(*each, i);
                 });
         });
 
@@ -549,7 +549,7 @@ mod tests {
                 .into_par_iter()
                 .zip(LEN..LEN + LEN / 2)
                 .for_each(|(each, i)| {
-                    assert_eq!((*each) as usize, i);
+                    assert_eq!(*each, i);
                 });
         });
 

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -365,7 +365,7 @@ mod tests {
 
     use rayon::prelude::*;
 
-    const LEN: usize = usize::BITS;
+    const LEN: u32 = usize::BITS;
     type Bucket<T> = super::Bucket<T, 1, { LEN as usize }>;
 
     #[test]

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -365,13 +365,14 @@ mod tests {
 
     use rayon::prelude::*;
 
-    type Bucket<T> = super::Bucket<T, 1, { usize::BITS as usize }>;
+    const LEN: usize = usize::BITS as usize;
+    type Bucket<T> = super::Bucket<T, 1, { LEN }>;
 
     #[test]
     fn test_basic() {
         let bucket: Arc<Bucket<u32>> = Arc::new(Bucket::new());
 
-        let arcs: Vec<_> = (0..64)
+        let arcs: Vec<_> = (0..LEN)
             .into_par_iter()
             .map(|i| {
                 let arc = Bucket::try_insert(&bucket, 0, i).unwrap();
@@ -411,7 +412,7 @@ mod tests {
     fn test_clone() {
         let bucket: Arc<Bucket<u32>> = Arc::new(Bucket::new());
 
-        let arcs: Vec<_> = (0..64)
+        let arcs: Vec<_> = (0..LEN)
             .into_par_iter()
             .map(|i| {
                 let arc = Bucket::try_insert(&bucket, 0, i).unwrap();
@@ -448,7 +449,7 @@ mod tests {
     fn test_reuse() {
         let bucket: Arc<Bucket<u32>> = Arc::new(Bucket::new());
 
-        let mut arcs: Vec<_> = (0..64)
+        let mut arcs: Vec<_> = (0..LEN)
             .into_par_iter()
             .map(|i| {
                 let arc = Bucket::try_insert(&bucket, 0, i).unwrap();
@@ -471,7 +472,7 @@ mod tests {
             assert_eq!(ArenaArc::strong_count(&arc), 1);
         }
 
-        let new_arcs: Vec<_> = (64..64 + 32)
+        let new_arcs: Vec<_> = (LEN..LEN + LEN / 2)
             .into_par_iter()
             .map(|i| {
                 let arc = Bucket::try_insert(&bucket, 0, i).unwrap();
@@ -492,7 +493,7 @@ mod tests {
         let handle2 = spawn(move || {
             new_arcs
                 .into_par_iter()
-                .zip(64..64 + 32)
+                .zip(LEN..LEN + LEN / 2)
                 .for_each(|(each, i)| {
                     assert_eq!((*each) as usize, i);
                 });
@@ -506,7 +507,7 @@ mod tests {
     fn test_reuse2() {
         let bucket: Arc<Bucket<u32>> = Arc::new(Bucket::new());
 
-        let mut arcs: Vec<_> = (0..64)
+        let mut arcs: Vec<_> = (0..LEN)
             .into_par_iter()
             .map(|i| {
                 let arc = Bucket::try_insert(&bucket, 0, i).unwrap();
@@ -525,7 +526,7 @@ mod tests {
             assert_eq!(ArenaArc::strong_count(&arc), 1);
         }
 
-        let new_arcs: Vec<_> = (64..64 + 32)
+        let new_arcs: Vec<_> = (LEN..LEN + LEN / 2)
             .into_par_iter()
             .map(|i| {
                 let arc = Bucket::try_insert(&bucket, 0, i).unwrap();
@@ -546,7 +547,7 @@ mod tests {
         let handle2 = spawn(move || {
             new_arcs
                 .into_par_iter()
-                .zip(64..64 + 32)
+                .zip(LEN..LEN + LEN / 2)
                 .for_each(|(each, i)| {
                     assert_eq!((*each) as usize, i);
                 });
@@ -560,7 +561,7 @@ mod tests {
     fn test_concurrent_remove() {
         let bucket: Arc<Bucket<u32>> = Arc::new(Bucket::new());
 
-        let arcs: Vec<_> = (0..64)
+        let arcs: Vec<_> = (0..LEN)
             .into_par_iter()
             .map(|i| {
                 let arc = Bucket::try_insert(&bucket, 0, i).unwrap();
@@ -587,7 +588,7 @@ mod tests {
     fn test_concurrent_remove2() {
         let bucket: Arc<Bucket<u32>> = Arc::new(Bucket::new());
 
-        let arcs: Vec<_> = (0..64)
+        let arcs: Vec<_> = (0..LEN)
             .into_par_iter()
             .map(|i| {
                 let arc = Bucket::try_insert(&bucket, 0, i).unwrap();
@@ -611,7 +612,7 @@ mod tests {
     fn realworld_test() {
         let bucket: Arc<Bucket<Mutex<u32>>> = Arc::new(Bucket::new());
 
-        (0..64).into_par_iter().for_each(|i| {
+        (0..LEN).into_par_iter().for_each(|i| {
             let arc = Bucket::try_insert(&bucket, 0, Mutex::new(i)).unwrap();
 
             assert_eq!(ArenaArc::strong_count(&arc), 2);

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -367,7 +367,7 @@ mod tests {
 
     use rayon::prelude::*;
 
-    type Bucket<T> = super::Bucket<T, 1, 64>;
+    type Bucket<T> = super::Bucket<T, 1, { usize::BITS }>;
 
     #[test]
     fn test_basic() {


### PR DESCRIPTION
Fixed #16

 - Bump msrv to 1.63
 - Rm interior mutability used in constants
 - Fix tests on 32-bit platform
 - Add CI to ensure tests succeed on 32-bit