### PR TITLE
Fix BitMap::new clippy: Do not create constant for type with interior…

### DIFF
--- a/src/bitmap.rs
+++ b/src/bitmap.rs
@@ -1,6 +1,6 @@
-use super::{array, thread_id::get_thread_id, SliceExt};
+use super::{thread_id::get_thread_id, SliceExt};
 
-use std::sync::atomic::{AtomicUsize, Ordering::Relaxed};
+use std::{array, sync::atomic::{AtomicUsize, Ordering::Relaxed}};
 
 fn compare_exchange(atomic: &AtomicUsize, curr: usize, new: usize) -> Result<(), usize> {
     atomic

--- a/src/bitmap.rs
+++ b/src/bitmap.rs
@@ -17,7 +17,7 @@ pub(crate) struct BitMap<const BITARRAY_LEN: usize>([AtomicUsize; BITARRAY_LEN])
 
 impl<const BITARRAY_LEN: usize> BitMap<BITARRAY_LEN> {
     pub(crate) fn new() -> Self {
-        Self(array::from_fn(|| AtomicUsize::new(0)))
+        Self(array::from_fn(|_| AtomicUsize::new(0)))
     }
 
     /// # Safety

--- a/src/bitmap.rs
+++ b/src/bitmap.rs
@@ -1,6 +1,9 @@
 use super::{thread_id::get_thread_id, SliceExt};
 
-use std::{array, sync::atomic::{AtomicUsize, Ordering::Relaxed}};
+use std::{
+    array,
+    sync::atomic::{AtomicUsize, Ordering::Relaxed},
+};
 
 fn compare_exchange(atomic: &AtomicUsize, curr: usize, new: usize) -> Result<(), usize> {
     atomic

--- a/src/bitmap.rs
+++ b/src/bitmap.rs
@@ -1,4 +1,4 @@
-use super::{thread_id::get_thread_id, SliceExt};
+use super::{array, thread_id::get_thread_id, SliceExt};
 
 use std::sync::atomic::{AtomicUsize, Ordering::Relaxed};
 
@@ -14,13 +14,7 @@ pub(crate) struct BitMap<const BITARRAY_LEN: usize>([AtomicUsize; BITARRAY_LEN])
 
 impl<const BITARRAY_LEN: usize> BitMap<BITARRAY_LEN> {
     pub(crate) fn new() -> Self {
-        // AtomicUsize is not Copyable, rustc suggests workaround
-        // by creating a const variable.
-
-        #[allow(clippy::declare_interior_mutable_const)]
-        const EMPTY_USIZE: AtomicUsize = AtomicUsize::new(0);
-
-        Self([EMPTY_USIZE; BITARRAY_LEN])
+        Self(array::from_fn(|| AtomicUsize::new(0)))
     }
 
     /// # Safety


### PR DESCRIPTION
… mutability